### PR TITLE
Replace per-module .gitignore by a single global file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Eclipse
+.settings/
+.classpath
+.project
+
+# IntelliJ IDEA
+.idea/
+*.iml
+.run/
+
+# Maven
+target/

--- a/secret-sharing-cli/.gitignore
+++ b/secret-sharing-cli/.gitignore
@@ -1,3 +1,0 @@
-/target/
-/.settings/
-/.classpath

--- a/secret-sharing-parent/.gitignore
+++ b/secret-sharing-parent/.gitignore
@@ -1,1 +1,0 @@
-/.settings/

--- a/secret-sharing-scheme/.gitignore
+++ b/secret-sharing-scheme/.gitignore
@@ -1,3 +1,0 @@
-/target
-/.settings/
-/.classpath

--- a/secret-sharing-server/.gitignore
+++ b/secret-sharing-server/.gitignore
@@ -1,3 +1,0 @@
-/target
-/.settings/
-/.classpath


### PR DESCRIPTION
By default, ignore Eclipse, IntelliJ IDEA and Maven files.

BTW, I would also recommend to delete the committed Eclipse project files from the repository altogether, but I leave that up to you as a maintainer.